### PR TITLE
Fix IIS compatibility

### DIFF
--- a/src/FTPBasicAPI.h
+++ b/src/FTPBasicAPI.h
@@ -40,7 +40,9 @@ class FTPBasicAPI {
     }
 
     is_open = true;
-    ;
+    const char *ok_result[] = {"200", nullptr};
+    cmd("OPTS", "UTF8", ok_result);
+
     return true;
   }
 

--- a/src/FTPFileIterator.h
+++ b/src/FTPFileIterator.h
@@ -83,6 +83,7 @@ class FTPFileIterator {
     buffer = "";
     if (stream_ptr != nullptr) {
       buffer = stream_ptr->readStringUntil('\n');
+      if (buffer.endsWith("\r")) buffer.remove(buffer.length() - 1);
       FTPLogger::writeLog(LOG_DEBUG, "line", buffer.c_str());
 
       // End of ls !!!


### PR DESCRIPTION
Closes #12 

Now I can properly get files lists and the characters are not messed up in non-ASCII file names